### PR TITLE
Accessibility improvements for the subscription options on the comment form

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -673,7 +673,7 @@ class Jetpack_Subscriptions {
 			$str .= '</li>';
 		}
 
-		$str .= "</ul></div>"
+		$str .= '</ul></div>';
 
 		/**
 		 * Filter the output of the subscription options appearing below the comment form.

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -89,7 +89,7 @@ class Jetpack_Subscriptions {
 			add_action( 'template_redirect', array( $this, 'widget_submit' ) );
 
 		// Set up the comment subscription checkboxes
-		add_action( 'comment_form', array( $this, 'comment_subscribe_init' ) );
+		add_action( 'comment_form_after_fields', array( $this, 'comment_subscribe_init' ) );
 
 		// Catch comment posts and check for subscriptions.
 		add_action( 'comment_post', array( $this, 'comment_subscribe_submit' ), 50, 2 );
@@ -630,11 +630,14 @@ class Jetpack_Subscriptions {
 
 		// Check if Mark Jaquith's Subscribe to Comments plugin is active - if so, suppress Jetpack checkbox
 
-		$str = '';
+		$unique_id = esc_attr( uniqid( 'jetpack-subscription-form-' ) );
+
+		// Add heading and wrap in list for assistive technology
+		$str = '<div><h4 id="'. esc_attr( $unique_id ).'" class="comment-subscription-form-title">Comment subscription preferences</h4><ul class="comment-subscription-form-list" aria-labelledby="'. esc_attr( $unique_id ).'">';
 
 		if ( FALSE === has_filter( 'comment_form', 'show_subscription_checkbox' ) && 1 == get_option( 'stc_enabled', 1 ) && empty( $post->post_password ) && 'post' == get_post_type() ) {
 			// Subscribe to comments checkbox
-			$str .= '<p class="comment-subscription-form"><input type="checkbox" name="subscribe_comments" id="subscribe_comments" value="subscribe" style="width: auto; -moz-appearance: checkbox; -webkit-appearance: checkbox;"' . $comments_checked . ' /> ';
+			$str .= '<li class="comment-subscription-form"><input type="checkbox" name="subscribe_comments" id="subscribe_comments" value="subscribe" style="width: auto; -moz-appearance: checkbox; -webkit-appearance: checkbox;"' . $comments_checked . ' /> ';
 			$comment_sub_text = __( 'Notify me of follow-up comments by email.', 'jetpack' );
 			$str .=	'<label class="subscribe-label" id="subscribe-label" for="subscribe_comments">' . esc_html(
 				/**
@@ -648,12 +651,12 @@ class Jetpack_Subscriptions {
 				 */
 				apply_filters( 'jetpack_subscribe_comment_label', $comment_sub_text )
 			) . '</label>';
-			$str .= '</p>';
+			$str .= '</li>';
 		}
 
 		if ( 1 == get_option( 'stb_enabled', 1 ) ) {
 			// Subscribe to blog checkbox
-			$str .= '<p class="comment-subscription-form"><input type="checkbox" name="subscribe_blog" id="subscribe_blog" value="subscribe" style="width: auto; -moz-appearance: checkbox; -webkit-appearance: checkbox;"' . $blog_checked . ' /> ';
+			$str .= '<li class="comment-subscription-form"><input type="checkbox" name="subscribe_blog" id="subscribe_blog" value="subscribe" style="width: auto; -moz-appearance: checkbox; -webkit-appearance: checkbox;"' . $blog_checked . ' /> ';
 			$blog_sub_text = __( 'Notify me of new posts by email.', 'jetpack' );
 			$str .=	'<label class="subscribe-label" id="subscribe-blog-label" for="subscribe_blog">' . esc_html(
 				/**
@@ -667,8 +670,10 @@ class Jetpack_Subscriptions {
 				 */
 				apply_filters( 'jetpack_subscribe_blog_label', $blog_sub_text )
 			) . '</label>';
-			$str .= '</p>';
+			$str .= '</li>';
 		}
+
+		$str .= "</ul></div>"
 
 		/**
 		 * Filter the output of the subscription options appearing below the comment form.

--- a/modules/subscriptions/subscriptions.css
+++ b/modules/subscriptions/subscriptions.css
@@ -5,3 +5,23 @@
 .comment-subscription-form .subscribe-label {
 	display: inline !important;
 }
+
+.comment-subscription-form-list {
+	padding: 0;
+	margin: 0;
+	list-style: none;
+}
+
+/* Meant only for screen readers */
+.comment-subscription-form-title {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important;
+}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Moves the subscription checkboxes from after the submit button to before the submit button
* Puts the checkboxes in a list for assistive technology
* Adds a header above the list for assistive technology

#### Testing instructions:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.

Would you like this feature to be tested by Beta testers as well?
Please add instructions to to-test.md in a new commit as part of your PR.
-->

* When viewing the subscription options underneath the comments box on a site, they check boxes should be over the Post Comment button and you should not see bullets.
![image](https://user-images.githubusercontent.com/44990/43659234-37cad834-9710-11e8-83fd-7b3661bf927d.png)


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Moves the subscription checkboxes from after the submit comment button to before the submit button. Improves the semantic markup of the list.